### PR TITLE
Feature/bson size

### DIFF
--- a/src/main/java/com/github/kohanyirobert/ebson/BsonDocument.java
+++ b/src/main/java/com/github/kohanyirobert/ebson/BsonDocument.java
@@ -196,7 +196,7 @@ public interface BsonDocument extends Map<String, Object> {
    */
   @Override
   void putAll(Map<? extends String, ? extends Object> map);
-
+  
   /**
    * {@linkplain BsonDocument Document} builder.
    * <p>

--- a/src/main/java/com/github/kohanyirobert/ebson/BsonDocuments.java
+++ b/src/main/java/com/github/kohanyirobert/ebson/BsonDocuments.java
@@ -37,6 +37,17 @@ public final class BsonDocuments {
   public static void writeTo(ByteBuffer buffer, BsonDocument document) {
     BsonToken.DOCUMENT.writer().writeTo(buffer, document);
   }
+  
+  /**
+   * Returns the binary size of the document. This is needed to allocate a
+   * ByteBuffer that is exactly the correct size.
+   * 
+   * @param document the document to obtain the binary size of
+   * @return the documents binary size
+   */
+  public static int binarySize(BsonDocument document){
+    return BsonToken.DOCUMENT.writer().getSize(document);
+  }
 
   /**
    * Returns a new document containing {@code map}'s key-value pairs.

--- a/src/main/java/com/github/kohanyirobert/ebson/BsonObject.java
+++ b/src/main/java/com/github/kohanyirobert/ebson/BsonObject.java
@@ -195,7 +195,7 @@ public enum BsonObject {
   public byte terminal() {
     return terminal;
   }
-
+  
   /**
    * Returns this object's associated {@linkplain Predicate predicate}.
    * 

--- a/src/main/java/com/github/kohanyirobert/ebson/BsonWriter.java
+++ b/src/main/java/com/github/kohanyirobert/ebson/BsonWriter.java
@@ -24,4 +24,11 @@ public interface BsonWriter {
    * little-endian byte ordering
    */
   void writeTo(ByteBuffer buffer, @Nullable Object reference);
+  
+  /**
+   * Returns the size of the reference object
+   * @param reference the object to return the size of
+   * @return the computed size
+   */
+  int getSize(@Nullable Object reference);
 }

--- a/src/main/java/com/github/kohanyirobert/ebson/BsonWriter.java
+++ b/src/main/java/com/github/kohanyirobert/ebson/BsonWriter.java
@@ -26,7 +26,8 @@ public interface BsonWriter {
   void writeTo(ByteBuffer buffer, @Nullable Object reference);
   
   /**
-   * Returns the size of the reference object
+   * Returns the size of the reference object.
+   * 
    * @param reference the object to return the size of
    * @return the computed size
    */

--- a/src/main/java/com/github/kohanyirobert/ebson/DefaultWriter.java
+++ b/src/main/java/com/github/kohanyirobert/ebson/DefaultWriter.java
@@ -17,6 +17,8 @@ import java.util.Map.Entry;
 import java.util.SortedSet;
 import java.util.regex.Pattern;
 
+import javax.annotation.Nullable;
+
 enum DefaultWriter implements BsonWriter {
 
   DOCUMENT {
@@ -32,6 +34,17 @@ enum DefaultWriter implements BsonWriter {
       buffer.put(BsonBytes.EOO);
       buffer.putInt(markedPosition, buffer.position() - markedPosition);
     }
+
+    @Override
+    public int getSize(Object reference) {
+      int constSize = 1 + 5;
+      int variableSize = 0;
+      BsonWriter fieldWriter = BsonToken.FIELD.writer();
+      for (Entry<?, ?> entry : ((Map<?, ?>) reference).entrySet()) {
+        variableSize += fieldWriter.getSize(entry);
+      }
+      return constSize + variableSize;
+    }
   },
 
   FIELD {
@@ -46,6 +59,19 @@ enum DefaultWriter implements BsonWriter {
       BsonToken.KEY.writer().writeTo(buffer, entry.getKey());
       bsonObject.writer().writeTo(buffer, entry.getValue());
     }
+
+    @Override
+    public int getSize(@Nullable Object reference) {
+      Entry<?, ?> entry = (Entry<?, ?>) reference;
+      BsonObject bsonObject = BsonObject.find(entry.getValue() == null
+          ? null
+          : entry.getValue().getClass());
+
+      int constSize = 1;
+      int variableSize = BsonToken.KEY.writer().getSize(entry.getKey()) +
+                         bsonObject.writer().getSize(entry.getValue());
+      return constSize + variableSize;
+    }
   },
 
   KEY {
@@ -53,6 +79,13 @@ enum DefaultWriter implements BsonWriter {
     @Override
     public void checkedWriteTo(ByteBuffer buffer, Object reference) {
       buffer.put(((String) reference).getBytes(Charsets.UTF_8)).put(BsonBytes.EOO);
+    }
+
+    @Override
+    public int getSize(@Nullable Object reference) {
+      int constSize = 1;
+      int variableSize = ((String) reference).getBytes(Charsets.UTF_8).length;
+      return constSize + variableSize;
     }
   },
 
@@ -62,6 +95,11 @@ enum DefaultWriter implements BsonWriter {
     public void checkedWriteTo(ByteBuffer buffer, Object reference) {
       buffer.putDouble(((Double) reference).doubleValue());
     }
+
+    @Override
+    public int getSize(@Nullable Object reference) {
+      return 8;
+    }
   },
 
   STRING {
@@ -70,6 +108,14 @@ enum DefaultWriter implements BsonWriter {
     public void checkedWriteTo(ByteBuffer buffer, Object reference) {
       byte[] bytes = ((String) reference).getBytes(Charsets.UTF_8);
       buffer.putInt(bytes.length + 1).put(bytes).put(BsonBytes.EOO);
+    }
+
+    @Override
+    public int getSize(@Nullable Object reference) {
+      int constSize = 5;
+      byte[] bytes = ((String) reference).getBytes(Charsets.UTF_8);
+      int variableSize = bytes.length;
+      return constSize + variableSize;
     }
   },
 
@@ -86,6 +132,18 @@ enum DefaultWriter implements BsonWriter {
       }
       BsonToken.DOCUMENT.writer().writeTo(buffer, document);
     }
+
+    @Override
+    public int getSize(@Nullable Object reference) {
+      Object array = reference instanceof Collection
+          ? ((Collection<?>) reference).toArray()
+          : reference;
+      Map<Object, Object> document = Maps.newLinkedHashMap();
+      for (int i = 0; i < Array.getLength(array); i++) {
+        document.put(String.valueOf(i), Array.get(array, i));
+      }
+      return BsonToken.DOCUMENT.writer().getSize(document);
+    }
   },
 
   BINARY {
@@ -99,6 +157,14 @@ enum DefaultWriter implements BsonWriter {
       bsonBinary.writer().writeTo(buffer, reference);
       buffer.putInt(markedPosition, buffer.position() - markedPosition - Ints.BYTES - 1);
     }
+
+    @Override
+    public int getSize(@Nullable Object reference) {
+      BsonBinary bsonBinary = BsonBinary.find(reference.getClass());
+      int constSize = 5;
+      int variableSize = bsonBinary.writer().getSize(reference);
+      return constSize + variableSize;
+    }
   },
 
   GENERIC {
@@ -107,6 +173,11 @@ enum DefaultWriter implements BsonWriter {
     public void checkedWriteTo(ByteBuffer buffer, Object reference) {
       buffer.put((byte[]) reference);
     }
+
+    @Override
+    public int getSize(@Nullable Object reference) {
+      return ((byte[]) reference).length;
+    }
   },
 
   OBJECT_ID {
@@ -114,6 +185,11 @@ enum DefaultWriter implements BsonWriter {
     @Override
     public void checkedWriteTo(ByteBuffer buffer, Object reference) {
       buffer.put(((BsonObjectId) reference).objectId());
+    }
+
+    @Override
+    public int getSize(@Nullable Object reference) {
+      return ((BsonObjectId) reference).objectId().capacity();
     }
   },
 
@@ -125,6 +201,11 @@ enum DefaultWriter implements BsonWriter {
           ? BsonBytes.TRUE
           : BsonBytes.FALSE);
     }
+
+    @Override
+    public int getSize(@Nullable Object reference) {
+      return 1;
+    }
   },
 
   UTC_DATE_TIME {
@@ -133,12 +214,22 @@ enum DefaultWriter implements BsonWriter {
     public void checkedWriteTo(ByteBuffer buffer, Object reference) {
       buffer.putLong(((Date) reference).getTime());
     }
+
+    @Override
+    public int getSize(@Nullable Object reference) {
+      return 8;
+    }
   },
 
   NULL {
 
     @Override
     public void checkedWriteTo(ByteBuffer buffer, Object reference) {}
+
+    @Override
+    public int getSize(@Nullable Object reference) {
+      return 0;
+    }
   },
 
   REGULAR_EXPRESSION {
@@ -149,6 +240,14 @@ enum DefaultWriter implements BsonWriter {
       BsonWriter keyWriter = BsonToken.KEY.writer();
       keyWriter.writeTo(buffer, regularExpression.pattern());
       keyWriter.writeTo(buffer, flagsToOptions(regularExpression.flags()));
+    }
+
+    @Override
+    public int getSize(@Nullable Object reference) {
+      Pattern regularExpression = (Pattern) reference;
+      BsonWriter keyWriter = BsonToken.KEY.writer();
+      return keyWriter.getSize(regularExpression.pattern()) + 
+             keyWriter.getSize(flagsToOptions(regularExpression.flags()));
     }
 
     // @do-not-check-next-line CyclomaticComplexity
@@ -185,6 +284,14 @@ enum DefaultWriter implements BsonWriter {
       ByteBuffer symbol = ((BsonSymbol) reference).symbol();
       buffer.putInt(symbol.capacity() + 1).put(symbol).put(BsonBytes.EOO);
     }
+
+    @Override
+    public int getSize(@Nullable Object reference) {
+      ByteBuffer symbol = ((BsonSymbol) reference).symbol();
+      int constSize = 5;
+      int variableSize = symbol.capacity();
+      return constSize + variableSize;
+    }
   },
 
   INT32 {
@@ -192,6 +299,11 @@ enum DefaultWriter implements BsonWriter {
     @Override
     public void checkedWriteTo(ByteBuffer buffer, Object reference) {
       buffer.putInt(((Integer) reference).intValue());
+    }
+
+    @Override
+    public int getSize(@Nullable Object reference) {
+      return 4;
     }
   },
 
@@ -201,6 +313,11 @@ enum DefaultWriter implements BsonWriter {
     public void checkedWriteTo(ByteBuffer buffer, Object reference) {
       buffer.put(((BsonTimestamp) reference).timestamp());
     }
+
+    @Override
+    public int getSize(@Nullable Object reference) {
+      return ((BsonTimestamp) reference).timestamp().capacity();
+    }
   },
 
   INT64 {
@@ -208,6 +325,11 @@ enum DefaultWriter implements BsonWriter {
     @Override
     public void checkedWriteTo(ByteBuffer buffer, Object reference) {
       buffer.putLong(((Long) reference).longValue());
+    }
+
+    @Override
+    public int getSize(@Nullable Object reference) {
+      return 8;
     }
   };
 

--- a/src/main/java/com/github/kohanyirobert/ebson/DefaultWriter.java
+++ b/src/main/java/com/github/kohanyirobert/ebson/DefaultWriter.java
@@ -5,7 +5,9 @@ import com.google.common.base.Joiner;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
+import com.google.common.primitives.Doubles;
 import com.google.common.primitives.Ints;
+import com.google.common.primitives.Longs;
 
 import java.lang.reflect.Array;
 import java.nio.ByteBuffer;
@@ -20,7 +22,7 @@ import java.util.regex.Pattern;
 import javax.annotation.Nullable;
 
 enum DefaultWriter implements BsonWriter {
-
+  
   DOCUMENT {
 
     @Override
@@ -37,7 +39,7 @@ enum DefaultWriter implements BsonWriter {
 
     @Override
     public int getSize(Object reference) {
-      int constSize = 1 + 5;
+      int constSize = BYTES_BYTES + Ints.BYTES;
       int variableSize = 0;
       BsonWriter fieldWriter = BsonToken.FIELD.writer();
       for (Entry<?, ?> entry : ((Map<?, ?>) reference).entrySet()) {
@@ -67,9 +69,9 @@ enum DefaultWriter implements BsonWriter {
           ? null
           : entry.getValue().getClass());
 
-      int constSize = 1;
-      int variableSize = BsonToken.KEY.writer().getSize(entry.getKey()) +
-                         bsonObject.writer().getSize(entry.getValue());
+      int constSize = BYTES_BYTES;
+      int variableSize = BsonToken.KEY.writer().getSize(entry.getKey())
+                         + bsonObject.writer().getSize(entry.getValue());
       return constSize + variableSize;
     }
   },
@@ -83,7 +85,7 @@ enum DefaultWriter implements BsonWriter {
 
     @Override
     public int getSize(@Nullable Object reference) {
-      int constSize = 1;
+      int constSize = BYTES_BYTES;
       int variableSize = ((String) reference).getBytes(Charsets.UTF_8).length;
       return constSize + variableSize;
     }
@@ -98,7 +100,7 @@ enum DefaultWriter implements BsonWriter {
 
     @Override
     public int getSize(@Nullable Object reference) {
-      return 8;
+      return Doubles.BYTES;
     }
   },
 
@@ -112,7 +114,7 @@ enum DefaultWriter implements BsonWriter {
 
     @Override
     public int getSize(@Nullable Object reference) {
-      int constSize = 5;
+      int constSize = Ints.BYTES + BYTES_BYTES;
       byte[] bytes = ((String) reference).getBytes(Charsets.UTF_8);
       int variableSize = bytes.length;
       return constSize + variableSize;
@@ -161,7 +163,7 @@ enum DefaultWriter implements BsonWriter {
     @Override
     public int getSize(@Nullable Object reference) {
       BsonBinary bsonBinary = BsonBinary.find(reference.getClass());
-      int constSize = 5;
+      int constSize = Ints.BYTES + BYTES_BYTES;
       int variableSize = bsonBinary.writer().getSize(reference);
       return constSize + variableSize;
     }
@@ -204,7 +206,7 @@ enum DefaultWriter implements BsonWriter {
 
     @Override
     public int getSize(@Nullable Object reference) {
-      return 1;
+      return BOOLEANS_BYTES;
     }
   },
 
@@ -217,7 +219,7 @@ enum DefaultWriter implements BsonWriter {
 
     @Override
     public int getSize(@Nullable Object reference) {
-      return 8;
+      return Longs.BYTES;
     }
   },
 
@@ -246,8 +248,8 @@ enum DefaultWriter implements BsonWriter {
     public int getSize(@Nullable Object reference) {
       Pattern regularExpression = (Pattern) reference;
       BsonWriter keyWriter = BsonToken.KEY.writer();
-      return keyWriter.getSize(regularExpression.pattern()) + 
-             keyWriter.getSize(flagsToOptions(regularExpression.flags()));
+      return keyWriter.getSize(regularExpression.pattern())
+             + keyWriter.getSize(flagsToOptions(regularExpression.flags()));
     }
 
     // @do-not-check-next-line CyclomaticComplexity
@@ -288,7 +290,7 @@ enum DefaultWriter implements BsonWriter {
     @Override
     public int getSize(@Nullable Object reference) {
       ByteBuffer symbol = ((BsonSymbol) reference).symbol();
-      int constSize = 5;
+      int constSize = Ints.BYTES + BYTES_BYTES;
       int variableSize = symbol.capacity();
       return constSize + variableSize;
     }
@@ -303,7 +305,7 @@ enum DefaultWriter implements BsonWriter {
 
     @Override
     public int getSize(@Nullable Object reference) {
-      return 4;
+      return Ints.BYTES;
     }
   },
 
@@ -329,9 +331,12 @@ enum DefaultWriter implements BsonWriter {
 
     @Override
     public int getSize(@Nullable Object reference) {
-      return 8;
+      return Longs.BYTES;
     }
   };
+  
+  private static final int BOOLEANS_BYTES = 1;
+  private static final int BYTES_BYTES = 1;
 
   @Override
   public final void writeTo(ByteBuffer buffer, Object reference) {

--- a/src/test/java/com/github/kohanyirobert/ebson/DefaultBinaryReaderWriterTest.java
+++ b/src/test/java/com/github/kohanyirobert/ebson/DefaultBinaryReaderWriterTest.java
@@ -83,8 +83,8 @@ public final class DefaultBinaryReaderWriterTest extends AbstractReaderWriterTes
     @Override
     public int getSize(@Nullable Object reference) {
       User user = (User) reference;
-      return BsonObject.STRING.writer().getSize(user.getName()) + 
-             BsonObject.INT32.writer().getSize(Integer.valueOf(user.getAge()));
+      return BsonObject.STRING.writer().getSize(user.getName())
+             + BsonObject.INT32.writer().getSize(Integer.valueOf(user.getAge()));
     }
   }
 

--- a/src/test/java/com/github/kohanyirobert/ebson/DefaultBinaryReaderWriterTest.java
+++ b/src/test/java/com/github/kohanyirobert/ebson/DefaultBinaryReaderWriterTest.java
@@ -79,6 +79,13 @@ public final class DefaultBinaryReaderWriterTest extends AbstractReaderWriterTes
       BsonObject.STRING.writer().writeTo(buffer, user.getName());
       BsonObject.INT32.writer().writeTo(buffer, Integer.valueOf(user.getAge()));
     }
+
+    @Override
+    public int getSize(@Nullable Object reference) {
+      User user = (User) reference;
+      return BsonObject.STRING.writer().getSize(user.getName()) + 
+             BsonObject.INT32.writer().getSize(Integer.valueOf(user.getAge()));
+    }
   }
 
   private static final class User {


### PR DESCRIPTION
This feature allows the developer to quickly calculate the exact size needed for a BsonDocument so that a ByteBuffer can be allocated properly.
